### PR TITLE
Fixed missing whitespace in sidebar

### DIFF
--- a/main.php
+++ b/main.php
@@ -69,6 +69,12 @@ jQuery(function ()
 
         });
 
+        //2017/09/20 Dirk Schnitzler: Apply spaces to the currently active page, too
+        jQuery(elem).find(">li>div>span>a").each(function()
+        {
+            jQuery(this).html(times + jQuery(this).html())
+        });
+
         jQuery(elem).find(">li>ul").each(function()
         {
             apply_space(jQuery(this), times + '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;');


### PR DESCRIPTION
When a sidebar is used, the current active link will be highlighted. In addition, a "span" is inserted which led to missing whitespaces for indentation. This made the currently active link appear on the very left which irritated our users.